### PR TITLE
Add apiKey methods query and header

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ On API server
 - sends back csrf token + http-only session cookie
 - call API as: api.php?csrf=\[csrf token] (session cookie is sent automatically)
 - (when using Angular2 or Vue2 the CSRF token is sent automatically)
+
+## With apiKey
+
+- Tested with swagger.io editor under Chrome
+- Both query and header methods are supported
+- See api.php for examples

--- a/api.php
+++ b/api.php
@@ -26,6 +26,48 @@
 //	exit(0);
 // }
 
+// for apiKey using key in query, in testing with the swagger editor
+//require 'auth.php';
+//$auth = new PHP_API_AUTH(array(
+//        'origin' => 'http://editor.swagger.io',
+//        'security'=>array(
+//                'CrudApiKeyQuery' => array(
+//                        'type' => 'apiKey',
+//                        'name' => 'apikey',
+//                        'in' => 'query',
+//                        'keys' => array(
+//                                'placekeyshereforaccess'
+//                        )
+//               )
+//       )
+//));
+//if ($auth->executeCommand()) exit(0);
+//if (!$auth->hasValidApiKey()) {
+//        header('HTTP/1.0 401 Unauthorized');
+//        exit(0);
+//}
+
+// for apiKey using key in header, in testing with the swagger editor
+//require 'auth.php';
+//$auth = new PHP_API_AUTH(array(
+//        'origin' => 'http://editor.swagger.io',
+//        'security'=>array(
+//                'CrudApiKeyHeader' => array(
+//                        'type' => 'apiKey',
+//                        'name' => 'apikey',
+//                        'in' => 'header',
+//                        'keys' => array(
+//                                'placekeyshereforaccess'
+//                        )
+//                )
+//        )
+//));
+//if ($auth->executeCommand()) exit(0);
+//if (!$auth->hasValidApiKey()) {
+//        header('HTTP/1.0 401 Unauthorized');
+//        exit(0);
+//} 
+
 // include your api code here:
 //
 // see: https://github.com/mevdschee/php-crud-api


### PR DESCRIPTION
Ref: https://github.com/mevdschee/php-crud-api/issues/197

This adds apiKey support that works with the swagger.io editor to support the query and header types.  The framework is generic enough and only works at the global level for now.   Application of fine grained control down to specific tables is a challenge for later.

I see the session key methods you are using.   I am wondering if that can be hooked into the oauth2 method in some way.

I had to at least add the "Accept" access method to the header to satisfy CORS issues with Chrome and the swagger.io editor (https://github.com/swagger-api/swagger-editor/blob/master/docs/cors.md).   Other methods are added if "Origin" is added.  If "Origin" is added, it is added into the headers too.   I also add the apikey names as needed.   We don't have to add the names for query.   I'll have to fix that to just add names for header types.  It is a bit too liberal now.

There are just a couple minor additions to add to the swagger definition in the api.php.  I'll create a separate pull request on that repo.